### PR TITLE
Allow checkout folder name to be different than brane

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ brane-let/
 brane-log/target
 examples/
 target/
+contrib/datastax/cpp-driver/build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 
+contrib/datastax/cpp-driver/
+
 ### Node ###
 # Logs
 logs

--- a/Dockerfile.log
+++ b/Dockerfile.log
@@ -11,7 +11,7 @@ COPY ./contrib/datastax /datastax
 
 # Build DataStax driver
 WORKDIR /datastax
-RUN make
+RUN make -j
 
 # Copy over relevant crates
 COPY ./brane-log /brane-log

--- a/Makefile
+++ b/Makefile
@@ -46,22 +46,22 @@ stop-instance: \
 	stop-services
 
 start-services:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-svc.yml up -d
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-svc.yml up -d
 
 stop-services:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-svc.yml down
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-svc.yml down
 
 start-brane:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-brn.yml up -d
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-brn.yml up -d
 
 stop-brane:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-brn.yml down
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-brn.yml down
 
 start-ide:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-ide.yml up -d
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-ide.yml up -d
 
 stop-ide:
-	COMPOSE_IGNORE_ORPHANS=1 docker-compose -f docker-compose-ide.yml down
+	COMPOSE_IGNORE_ORPHANS=1 docker-compose -p brane -f docker-compose-ide.yml down
 
 # Kubernetes in Docker (kind)
 

--- a/contrib/datastax/Makefile
+++ b/contrib/datastax/Makefile
@@ -20,7 +20,7 @@ build: checkout
 	&& mkdir -p build \
 	&& cd build \
 	&& cmake .. \
-	&& make \
+	&& make -j \
 	&& make install
 
 checkout:

--- a/contrib/xenon/Dockerfile.slurm
+++ b/contrib/xenon/Dockerfile.slurm
@@ -21,8 +21,8 @@ RUN wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/sin
     tar -xzf singularity-${VERSION}.tar.gz && \
     cd singularity && \
     ./mconfig -p /usr/local/singularity && \
-    make -C ./builddir && \
-    make -C ./builddir install
+    make -j -C ./builddir && \
+    make -j -C ./builddir install
 
 FROM nlesc/xenon-slurm
 

--- a/examples/camelyon/README.md
+++ b/examples/camelyon/README.md
@@ -16,7 +16,7 @@ $ brane list
 ```
 
 ## 3. Start a local Brane deployment
-Navigate to the Docker deployment folder, and run `docker-compose`.
+Navigate to the Docker deployment folder, and run `docker-compose -p brane`.
 ```shell
 $ cd ./deployment/docker
 $ docker-compose up -d


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces improved compile speed by using multiple cores by default (`make -j` instead of `make`) and allows the repo root directory name to be different than `brane`, e.g. `brane-upstream` or `brane-src`, which can be useful for avoiding name clashes.


* **What is the current behavior?** (You can also link to an open issue here)
    Currently, if the repo is cloned under a different name, e.g.
    ```bash
    git clone https://github.com/onnovalkering/brane.git brane-src
    ```
    then `make jupyterlab-token` will not be able to extract the access token since the docker containers started with `make start-ide` will not have the name `brane_brane-ide_1`.

* **What is the new behavior (if this is a feature change)?**
Cloning under a different name will work as expected and does so by setting the docker compose project name to `brane` explicitly.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There are no breaking changes.



* **Other information**: